### PR TITLE
feat(telestaff): persist session cookies and expose get_cookies()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,130 +1,64 @@
 # festis
 
-A really simple python client library for Workforce Telestaff.
+A small Python client library for Kronos Workforce Telestaff (HTML scraping + authenticated session handling).
 
-## Getting Started
+## Prerequisites
 
-These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. See deployment for notes on how to deploy the project on a live system.
+Python 3.8+ is recommended. Install dependencies:
 
-### Prerequisites
-
-This module is designed to work with `Python 3.4+`.  `Python 2` may work, your milage may very.  The `requirements.txt` file contains the required libraries.  
-
-```
-python3.4+
-$pip install -r requirements.txt
+```bash
+pip install -r requirements.txt
 ```
 
+Optional: [requests-ntlm](https://github.com/requests/requests-ntlm) if Telestaff sits behind NTLM challenge-response authentication:
 
-### Optional Prerequisites
-
-The python [requests-ntlm](https://github.com/requests/requests-ntlm) module can optionally be used to authenticate with Workforce Telestaff installations behind a NTLM Challenge-Response authorization mechanizm.  
-
+```bash
+pip install requests-ntlm
 ```
 
-pip install requests_ntlm
+## Installation
 
-``` 
-
-
-### Installation
-
-This package can be installed from github:
-
-```
-$ git clone http://github.com/porcej/festis
-$ cd festis
-$ python3 setup.py install
+```bash
+git clone https://github.com/porcej/festis.git
+cd festis
+pip install .
 ```
 
-### Removal
+## Usage
 
-
-```
-$ pip uninstall festis
-```
-
-### Usage
-
-#### Using this module in your application
-
-Import the telestaff class from the festis module
-```
+```python
 from festis import telestaff as ts
+
+telestaff = ts.Telestaff(
+    host="https://telestaff.example.org",
+    t_user="...",
+    t_pass="...",
+    domain="...",
+    d_user="...",
+    d_pass="...",
+    cookies=None,  # optional: "name=value; name2=value2" from a prior session
+)
+
+telestaff.do_login()
+result = telestaff.get_telestaff(kind="roster", date=None)
+# result is {"status_code": int, "data": ...}
+cookies = telestaff.get_cookies()
 ```
 
+See `sample.py` and `samplefile.py` for runnable examples.
 
+## Development tests
 
-Initilize a telestaff object and request the desired data 
-
-```
-telestaff = ts.Telestaff(host=current_app.config['TS_SERVER'],  \
-                                    t_user=current_app.config['TS_USER'], \
-                                    t_pass=current_app.config['TS_PASS'], \
-                                    domain=current_app.config['TS_DOMAIN'],  \
-                                    d_user=current_app.config['D_USER'], \
-                                    d_pass=current_app.config['D_PASS'])
-
-telestaff.getTelestaff(kind='roster', date=date, jsonExport=True)
+```bash
+pip install pytest
+pytest
 ```
 
+## Built with
 
-### Sample applicaitons
-
-#### sample.py
-
-The sample applicaiton, `sample.py` demonstrates using a911 to pretty print alert data to the screen.  
-
-```
-Usage: sample.py [options]
-
-Options:
-  -h, --help                show this help message and exit
-  -q, --quiet               set logging to ERROR
-  -d, --debug               set logging to DEBUG
-  -v, --verbose             set logging to COMM
-  -a AREG, --aid=AREG       Active911 Registration ID
-```
-
-
-#### samplefile.py
-The example applicaiton, `samplefile.py` demonstrates using a911's Active911 class to save alert messages as json files in a predefined directory.
-
-```
-Usage: samplefile.py [options]
-
-Options:
-  -h, --help            show this help message and exit
-  -q, --quiet           set logging to ERROR
-  -d, --debug           set logging to DEBUG
-  -v, --verbose         set logging to COMM
-  -a AREG, --aid=AREG   Active911 Registration ID
-  -p OPATH, --path=OPATH
-                        Output directory
-```
-
-
-## Built With
-
-* [Anaconda Python](https://conda.io/) - The python framework
-* [Beautiful Soup](https://www.crummy.com/software/BeautifulSoup/) - Screen Scraping
-* [Requests](http://docs.python-requests.org/en/master/) - Request and session handling
-
-## Contributing
-
-Please read [CONTRIBUTING.md](https://gist.github.com/porcej/cc71497a2b455f27bca8c879731e68dc) for details on our code of conduct, and the process for submitting pull requests to us.
-
-## Versioning
-
-We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/porcej/a911_bridge/tags). 
-
-## Authors
-
-* **Joseph Porcelli** - *Initial work* - [porcej](https://github.com/porcej)
-
-See also the list of [contributors](https://github.com/porcej/a911_bridge/contributors) who participated in this project.
+- [Beautiful Soup](https://www.crummy.com/software/BeautifulSoup/) — HTML parsing
+- [Requests](https://requests.readthedocs.io/) — HTTP session and cookies
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details
-
+MIT — see the `LICENSE` file in this repository.

--- a/festis/__init__.py
+++ b/festis/__init__.py
@@ -2,14 +2,14 @@
 # -*- coding: ascii -*-
 
 """
-Festis.telestaff: downlaods data from telestaff
+Festis.telestaff: downloads data from telestaff
 """
 
 __author__ = 'Joe Porcelli (porcej@gmail.com)'
 __copyright__ = 'Copyright (c) 2017 Joe Porcelli'
 __license__ = 'New-style BSD'
 __vcs_id__ = '$Id$'
-__version__ = '0.1.2' #Versioning: http://www.python.org/dev/peps/pep-0386/
+__version__ = '0.1.3' #Versioning: http://www.python.org/dev/peps/pep-0386/
 
 
 from festis import telestaff

--- a/festis/telestaff.py
+++ b/festis/telestaff.py
@@ -36,6 +36,8 @@ Changelog:
     - 2022-11-13 - Added position id
     =======================================================================================
     * 2024-10-30 - Moved to version 0.1.2
+    - 2026-04-04 - Persist session cookies after get_telestaff; added get_cookies()
+    - 2026-04-04 - Fix do_login return, domain_user NTLM call, f-strings, picklist except; trim deps
 
 """
 
@@ -43,9 +45,8 @@ __author__ = 'Joe Porcelli (porcej@gmail.com)'
 __copyright__ = 'Copyright (c) 2024 Joe Porcelli'
 __license__ = 'New-style BSD'
 __vcs_id__ = '$Id$'
-__version__ = '0.1.2' #Versioning: http://www.python.org/dev/peps/pep-0386/
+__version__ = '0.1.3' #Versioning: http://www.python.org/dev/peps/pep-0386/
 
-import base64
 from urllib.parse import urlparse
 
 from requests import Session, RequestException, HTTPError, codes
@@ -58,7 +59,6 @@ except ImportError: HttpNtlmAuth = None
 from bs4 import BeautifulSoup
 from datetime import datetime
 import re
-import yaml
 import logging
 
 
@@ -133,6 +133,14 @@ class Telestaff():
         self.session.verify = self.creds['verify_ssl_cert']
         self.session.headers.update({'User-Agent': self.userAgent})
 
+    def _sync_cookies_from_session(self) -> None:
+        """Copy cookies from the requests session into creds (after responses update the jar)."""
+        self.creds.setdefault('cookies', {})
+        self.creds['cookies'].update(self.session.cookies.get_dict())
+
+    def get_cookies(self) -> Dict[str, str]:
+        """Return a copy of cookies last synced from the session (e.g. after get_telestaff)."""
+        return dict(self.creds.get('cookies', {}))
 
     def set_cookies_from_string(self, cookie_string: str) -> None:
         """
@@ -666,7 +674,7 @@ class Telestaff():
 
             # Handle NTLM authentication if necessary
             if login_page_response.status_code == codes.unauthorized and HttpNtlmAuth:
-                self.session.auth = HttpNtlmAuth(self.domainUser(), self.creds['domain_pass'])
+                self.session.auth = HttpNtlmAuth(self.domain_user(), self.creds['domain_pass'])
                 login_page_response = self.session.get(self.resource_url('loginPage'))
 
             login_page_response.raise_for_status()
@@ -691,15 +699,15 @@ class Telestaff():
                 self.session.get(self.resource_url('contactLog?myContactLog=true'))
                 self.session.get(self.resource_url('contactLog?dispositionedUnrespondedLogs=true'))
 
-            return self.build_response_dict(login_response.status_code, data)
+            self._sync_cookies_from_session()
+            return self.build_response_dict(login_response.status_code, login_response.url)
 
         except HTTPError as e:
-            return self.build_response_dict(500, "Login failed with HTTP Error: {e}")
+            return self.build_response_dict(500, f"Login failed with HTTP Error: {e}")
         except RequestException as e:
-            return self.build_response_dict(500, "Login failed with error: {e}")
-            return {'status_code': f'Login failed with error {e}'}
+            return self.build_response_dict(500, f"Login failed with error: {e}")
         except Exception as e:
-            return self.build_response_dict(500, "Login failed with unknown error: {e}")
+            return self.build_response_dict(500, f"Login failed with unknown error: {e}")
 
 
     def do_logout(self) -> Union[Dict[str, int], bool]:
@@ -712,17 +720,18 @@ class Telestaff():
         try:
             # Initial login page request
             logout_page_response = self.session.get(self.resource_url('logout'))
+            self._sync_cookies_from_session()
 
             logout_page_response.raise_for_status()
             if self.check_if_logged_out(logout_page_response.url):
                 return self.build_response_dict(200, "Logged out")
+            return self.build_response_dict(logout_page_response.status_code, logout_page_response.url)
         except HTTPError as e:
-            return self.build_response_dict(500, "Logout failed with HTTP Error: {e}")
+            return self.build_response_dict(500, f"Logout failed with HTTP Error: {e}")
         except RequestException as e:
-            return self.build_response_dict(500, "Logout failed with error: {e}")
-            return {'status_code': f'Logout failed with error {e}'}
+            return self.build_response_dict(500, f"Logout failed with error: {e}")
         except Exception as e:
-            return self.build_response_dict(500, "Logout failed with unknown error: {e}")
+            return self.build_response_dict(500, f"Logout failed with unknown error: {e}")
 
     def check_if_logged_out(self, url: str) -> bool:
         """
@@ -764,6 +773,7 @@ class Telestaff():
         """
         try:
             response = self.session.get(path)
+            self._sync_cookies_from_session()
             response.raise_for_status()
             if self.check_if_logged_out(response.url):
                 return self.build_response_dict(403, 'Telestaff username and password combination is incorrect.')
@@ -843,6 +853,7 @@ class Telestaff():
         
         # Initial picklist request
         response = self.session.get(r_url)
+        self._sync_cookies_from_session()
         response.raise_for_status()  # Ensure request succeeded
 
         # If chain parameter is provided, fetch custom picklist
@@ -858,10 +869,12 @@ class Telestaff():
             
             # Submit the custom picklist request
             self.session.post(self.resource_url('customPickList'), data=picklist_data)
+            self._sync_cookies_from_session()
 
         # Fetch the final picklist data
         try:
             response = self.session.get(self.resource_url('pickListData'))
+            self._sync_cookies_from_session()
             response.raise_for_status()  # Check for successful data retrieval
             
             # Check if still logged in
@@ -873,9 +886,9 @@ class Telestaff():
             data['type'] = 'picklist'
             return self.build_response_dict(200, data)
 
-        except requests.exceptions.RequestException as e:
+        except RequestException as e:
             logging.warning(f"Error fetching picklist data: {e}")
-            return self.build_response_dict(500, "Failed to retrieve picklist data: {e}")
+            return self.build_response_dict(500, f"Failed to retrieve picklist data: {e}")
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 beautifulsoup4>=4.6.0
-DateTime>=4.2
 requests>=2.21.0
-pyyaml>=5.4

--- a/sample.py
+++ b/sample.py
@@ -2,7 +2,7 @@
 # -*- coding: ascii -*-
 
 """
-Sample App to demonstrage festis
+Sample app demonstrating festis Telestaff usage.
 
 Changelog:
     - 2018-12-16 - Initial Commit
@@ -15,28 +15,19 @@ __copyright__ = "Copyright (c) 2018 Joseph Porcelli"
 __license__ = "MIT"
 
 import os
-import sys
-import logging
 from festis import telestaff as ts
-from pprint import pprint 
-
-
-
-# Here we handle some command line input funkyness
-if sys.version_info < (3, 0):
-    reload(sys)
-    sys.setdefaultencoding('utf8')
-else:
-    raw_input = input
+from pprint import pprint
 
 
 TS_DOMAIN = os.environ.get('TS_DOMAIN') or 'NTLM DOMAIN FOR AUTHENTICATION'
-TS_SERVER = os.environ.get('TS_SERVER') or 'TELESTAFF URL'
+TS_SERVER = os.environ.get('TS_SERVER') or 'https://telestaff.example.org'
 
 TS_USER = os.environ.get('TS_USER') or 'TELESTAFF USER'
 TS_PASS = os.environ.get('TS_PASS') or 'TELESTAFF PASSWORD'
 D_USER = os.environ.get('D_USER') or 'DOMAIN USER'
 D_PASS = os.environ.get('D_PASS') or 'DOMAIN USER PASSWORD'
+# Optional: paste a Cookie header from a browser session to skip re-auth when still valid
+COOKIES = os.environ.get('COOKIES')
 date = None
 
 
@@ -46,8 +37,13 @@ if __name__ == '__main__':
                                 t_pass=TS_PASS, \
                                 domain=TS_DOMAIN,  \
                                 d_user=D_USER, \
-                                d_pass=D_PASS)
+                                d_pass=D_PASS, \
+                                cookies=COOKIES)
+    telestaff.do_login()
+    response = telestaff.get_telestaff(kind="rosterFull", date=date)
 
-    pprint( telestaff.getTelestaff(kind='roster', date=date, jsonExport=True ) )
+    pprint(telestaff.get_cookies())
+    # pprint(response)
 
-
+    # with open('roster.json', 'w') as jfh:
+    #     json.dump(telestaff.get_telestaff(kind='roster', date=date), jfh)

--- a/samplefile.py
+++ b/samplefile.py
@@ -2,7 +2,7 @@
 # -*- coding: ascii -*-
 
 """
-Sample App to demonstrage dumping a festis roster to file
+Sample app: log in, fetch roster, write JSON to roster.json
 
 Changelog:
     - 2018-12-16 - Initial Commit
@@ -15,23 +15,12 @@ __copyright__ = "Copyright (c) 2018 Joseph Porcelli"
 __license__ = "MIT"
 
 import os
-import sys
-import logging
 import json
 from festis import telestaff as ts
 
 
-
-# Here we handle some command line input funkyness
-if sys.version_info < (3, 0):
-    reload(sys)
-    sys.setdefaultencoding('utf8')
-else:
-    raw_input = input
-
-
 TS_DOMAIN = os.environ.get('TS_DOMAIN') or 'NTLM DOMAIN FOR AUTHENTICATION'
-TS_SERVER = os.environ.get('TS_SERVER') or 'TELESTAFF URL'
+TS_SERVER = os.environ.get('TS_SERVER') or 'https://telestaff.example.org'
 
 TS_USER = os.environ.get('TS_USER') or 'TELESTAFF USER'
 TS_PASS = os.environ.get('TS_PASS') or 'TELESTAFF PASSWORD'
@@ -48,7 +37,7 @@ if __name__ == '__main__':
                                 d_user=D_USER, \
                                 d_pass=D_PASS)
 
+    telestaff.do_login()
+
     with open('roster.json', 'w') as jfh:
-        json.dump(telestaff.getTelestaff(kind='roster', date=date, jsonExport=True ), jfh)
-
-
+        json.dump(telestaff.get_telestaff(kind='roster', date=date), jfh, indent=2)

--- a/setup.py
+++ b/setup.py
@@ -51,21 +51,10 @@ def read_requirements():
 
 CLASSIFIERS      = [ 'Intended Audience :: Developers',
                      'License :: OSI Approved :: MIT License',
-                     'Programming Language :: Python',
-                     'Programming Language :: Python :: 2.7',
-                     'Programming Language :: Python :: 3.4',
-                     'Programming Language :: Python :: 3.5',
-                     'Programming Language :: Python :: 3.6',
-                     'Programming Language :: Python :: 3.7',
+                     'Programming Language :: Python :: 3',
+                     'Programming Language :: Python :: 3 :: Only',
                      'Topic :: Software Development :: Libraries :: Python Modules',
                    ]
-
-REQUIREMENTS    = [
-                    'beautifulsoup4>=4.6.0',
-                    'DateTime>=4.2',
-                    'requests>=2.21.0',
-                    'pyyaml>=4.2b1'
-                ]
 
 packages     = [ 'festis' ]
 
@@ -81,6 +70,7 @@ setup(
     license      = 'MIT',
     platforms    = [ 'any' ],
     packages     = packages,
+    python_requires  = '>=3.8',
     install_requires    = read_requirements(),
     classifiers  = CLASSIFIERS
 )

--- a/tests/test_telestaff.py
+++ b/tests/test_telestaff.py
@@ -1,0 +1,14 @@
+"""Lightweight tests for festis.telestaff (no network)."""
+
+from festis.telestaff import Telestaff
+
+
+def test_set_cookies_from_string_roundtrip():
+    t = Telestaff(host='https://example.com')
+    t.set_cookies_from_string('a=1; b=two')
+    assert t.get_cookies() == {'a': '1', 'b': 'two'}
+
+
+def test_domain_user_concat():
+    t = Telestaff(host='https://example.com', domain='DOM', d_user='\\user')
+    assert t.domain_user() == 'DOM\\user'


### PR DESCRIPTION
After Telestaff HTTP responses, copy the requests session cookie jar into creds so callers can read the latest values. Wire sync into get_telestaff data and picklist paths; add get_cookies() returning a copy of the map.

fix: repair Telestaff login/logout, deps, docs, and samples

- Fix do_login success return (undefined data) and NTLM domain_user call
- Use f-strings for login/logout/picklist errors; fix picklist RequestException
- do_logout: always return a result; sync cookies after logout GET
- Drop unused imports (base64, yaml); remove DateTime/pyyaml from requirements
- setup: single install_requires via requirements.txt, python_requires>=3.8, classifiers
- Bump version to 0.1.3; fix __init__ docstring typo
- Rewrite README; refresh sample.py and samplefile.py for current API
- Add pytest smoke tests for cookies and domain_user

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core session/auth flow by syncing cookies after requests and adjusting login/logout and picklist error handling, which could affect authentication behavior. Changes are still localized and covered by small no-network tests.
> 
> **Overview**
> Adds cookie persistence to the Telestaff client by syncing the requests session cookie jar back into `creds` after key requests, and exposes `get_cookies()` so callers can reuse authenticated sessions.
> 
> Fixes several correctness issues in auth and data fetching: repairs the NTLM `domain_user()` call, ensures `do_login`/`do_logout` return consistent response dicts, and improves picklist exception handling and error messages. Updates packaging/docs (Python 3.8+ requirement, trimmed deps), refreshes samples to the `get_telestaff` API, bumps version to `0.1.3`, and adds lightweight pytest smoke tests for cookies and `domain_user()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42171781e0bd97fe627ae29224d33c891bd6cc8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->